### PR TITLE
Default value removed for TimeZone

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -30,8 +30,7 @@ onBeforeInit: |
         required: true,
         width: 250,
         editable: true,
-        values: values,
-        default: TimeZone.getDefault().getID()
+        values: values
       })
   return jps;
 


### PR DESCRIPTION
Removed  default: TimeZone.getDefault().getID() in onBeforeInit